### PR TITLE
refactor login, remove notifications since its handled once you login

### DIFF
--- a/src/containers/auth/CreateAccount/index.tsx
+++ b/src/containers/auth/CreateAccount/index.tsx
@@ -80,7 +80,7 @@ const CreateAccount = () => {
       };
 
       registerUserMutation({
-        variables: { CreateUserInput: data },
+        variables: { createUserInput: data },
       }).then((response) => {
         if (response && response?.data?.createUser) {
           setModalState(true);

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useCallback } from "react";
-import { Platform, View } from "react-native";
+import React from "react";
+import { View } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
@@ -8,41 +8,18 @@ import { useAppSelector } from "../store/hooks";
 import AuthNavigator from "./AuthNavigator";
 import screenName from "../utils/constants/screenName";
 import ProfileNavigator from "./ProfileNavigator/ProfileNavigator";
-import { useNotifications } from "../hooks/useNotification";
-import notificationAxios from "../services/axios/notificationAxios";
 import { navigationRef } from "./RootNavigation";
 
 const Stack = createNativeStackNavigator();
 const prefix = Linking.createURL("/");
 
 const Navigator = () => {
-  const { user } = useAppSelector((state) => state.appUser);
-  const { registerForPushNotificationsAsync } = useNotifications();
-
+ 
   const linking = {
     prefixes: [prefix],
   };
 
-  const saveNotificationToken = useCallback(
-    async (usr: any) => {
-      const notificationToken = await registerForPushNotificationsAsync();
-      if (notificationToken) {
-        await notificationAxios.put("deviceToken", {
-          notificationToken,
-          osType: Platform.OS,
-          version: Platform.Version,
-          userId: usr.userId,
-        });
-      }
-    },
-    [registerForPushNotificationsAsync]
-  );
-
-  useEffect(() => {
-    if (user) {
-      saveNotificationToken(user);
-    }
-  }, [user, saveNotificationToken]);
+  const { user } = useAppSelector((state) => state.appUser);
 
   return (
     <View style={{ flex: 1 }}>

--- a/src/services/graphql/auth/mutations.ts
+++ b/src/services/graphql/auth/mutations.ts
@@ -47,14 +47,14 @@ export const FORGOT_PASSWORD = gql`
 `;
 
 export const CREATE_USER = gql`
-  mutation CreateUser($CreateUserInput: CreateUserInput!) {
-    createUser(createUserInput: $CreateUserInput)
+  mutation CreateUser($createUserInput: CreateUserInput!) {
+    createUser(createUserInput: $createUserInput)
   }
 `;
 
 export const LOG_IN_USER = gql`
-  mutation Login($LoginUserInput: LoginUserInput!) {
-    login(loginUserInput: $LoginUserInput) {
+  mutation Login($loginUserInput: LoginUserInput!) {
+    login(loginUserInput: $loginUserInput) {
       token
       user {
         userId
@@ -70,8 +70,8 @@ export const LOG_IN_USER = gql`
 `;
 
 export const PROVIDER_LOGIN = gql`
-  mutation LoginWithProvider($AuthProviderInput: AuthProviderInput!) {
-    loginWithProvider(authProviderInput: $AuthProviderInput) {
+  mutation LoginWithProvider($authProviderInput: AuthProviderInput!) {
+    loginWithProvider(authProviderInput: $authProviderInput) {
       token
       user {
         userId


### PR DESCRIPTION
## What?

- [ ] bug fix
- [ ] feature
- [ ] enhancement
- [x] refactor

## description 
Refactored Provider login so its cleaner and has more code reuse,
removed duplicate initiation of notifications, it should all be handled once the user is authenticated since it replies on a userId
renamed mutations to lower case to match naming convention

## Why?
easier to read, error handling, code reuse
match mutations cod naming

## How?

## Testing?
tested ability to login

## Screenshots (optional)

## Anything Else?
