### PR TITLE
Remove useUpdateUserLocation hook

### DIFF
--- a/src/navigation/ProfileNavigator/ProfileNavigator.tsx
+++ b/src/navigation/ProfileNavigator/ProfileNavigator.tsx
@@ -5,7 +5,6 @@ import UserProfile from "../../containers/home/UserProfile";
 import AppNavigator from "../AppNavigator";
 import Messages from "../../containers/chat/Messages";
 import { useFetchStaticData } from "./hooks/useFetchStaticData";
-import { useUpdateUserLocation } from "../../hooks/useLocation";
 import { useGetUserConversations } from "../../hooks/useGetUserConversations";
 import { useGetUserPreference } from "../../hooks/useGetUserPreference";
 import { useGetUserProfile } from "../../hooks/useGetUserProfile";
@@ -19,7 +18,6 @@ const ProfileNavigator = () => {
   // useGetUserPreference();
   useGetUserProfile();
   useFetchStaticData();
-  useUpdateUserLocation();
   // useGetUserChoices();
 
   return (


### PR DESCRIPTION
## What?
A hook that is used to get the current location of the user on the app is removed

- [ ] bug fix
- [ ] feature
- [ ] enhancement
- [x] refactor

## Description 
- SCOOP- 496

## Why?
The app will provide users with the flexibility to make changes to their location.

## How?
A google maps integrated component will be used to assist users with adding their address.

## Testing?

## Screenshots (optional)

## Anything Else?
